### PR TITLE
docs: Fix incorrect article usage before "AWS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # op-enclave
 
 `op-enclave` is a relatively small modification to the [op-stack](https://github.com/ethereum-optimism/optimism/)
-that proves state transitions in a AWS Nitro Enclave, and submits the resulting state roots to the L1 chain.
+that proves state transitions in an AWS Nitro Enclave, and submits the resulting state roots to the L1 chain.
 This removes the need for the 7-day challenge period, and allows for immediate withdrawals.
 
 ## Directory Structure


### PR DESCRIPTION
A small mistake in the text where "a AWS Nitro Enclave" was used.
Since "AWS" is pronounced with a vowel sound at the beginning, I've corrected it to "an AWS Nitro Enclave."