### PR TITLE
fix: error handling in server initialization and listener setup

### DIFF
--- a/op-enclave/cmd/enclave/main.go
+++ b/op-enclave/cmd/enclave/main.go
@@ -17,20 +17,26 @@ func main() {
 	serv, err := enclave2.NewServer()
 	if err != nil {
 		log.Crit("Error creating API server", "error", err)
+		return
 	}
+
 	err = s.RegisterName(enclave2.Namespace, serv)
 	if err != nil {
 		log.Crit("Error registering API", "error", err)
+		return
 	}
 
 	listener, err := vsock.Listen(1234, &vsock.Config{})
 	if err != nil {
 		log.Warn("Error opening vsock listener, running in HTTP mode", "error", err)
 		err = http.ListenAndServe(":1234", s)
+		if err != nil {
+			log.Crit("Error starting HTTP server", "error", err)
+		}
 	} else {
 		err = s.ServeListener(listener)
-	}
-	if err != nil {
-		log.Crit("Error starting server", "error", err)
+		if err != nil {
+			log.Crit("Error starting server", "error", err)
+		}
 	}
 }


### PR DESCRIPTION
In this update, I’ve addressed a few issues related to error handling in the server initialization and listener setup process.

Changes made:
- Added `return` statements after critical errors in `NewServer()` and `RegisterName()` to ensure the program halts correctly if these errors occur.
- Improved error handling for the `vsock.Listen` failure. If the error is not fatal, it logs the issue and proceeds to attempt starting the HTTP server.
- Introduced error checks when starting both the HTTP server and `vsock` listener to ensure no errors are missed.

These changes make the code more robust and prevent potential issues during runtime.